### PR TITLE
feature: add rename to DeltaItem trait and support rename for column/constraints of the table

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,13 +103,15 @@ pub trait MigrationPlanner {
 }
 
 /// A trait for the diff object to generate proper migration sql
-pub trait DeltaItem {
+pub trait DeltaItem: ToString {
     /// The node which will be used to generated the final SQL
     type SqlNode: NodeItem;
     /// generate sql for drop
     fn drop(self, node: &Self::SqlNode) -> Result<Vec<String>>;
     /// generate sql for create
     fn create(self, node: &Self::SqlNode) -> Result<Vec<String>>;
+    /// generate rename SQL
+    fn rename(self, node: &Self::SqlNode, new: Self) -> Result<Vec<String>>;
     /// generate sql for alter
     fn alter(self, node: &Self::SqlNode, new: Self) -> Result<Vec<String>>;
 }

--- a/src/parser/table/column/constraint_info.rs
+++ b/src/parser/table/column/constraint_info.rs
@@ -2,35 +2,10 @@ use crate::{
     parser::{utils::node_to_string, ConstraintInfo, Table},
     DeltaItem,
 };
-use anyhow::Result;
 use pg_query::{protobuf::ConstrType, NodeEnum};
+use std::fmt;
 
-impl ConstraintInfo {
-    pub(super) fn generate_sql(&self) -> Result<String> {
-        let s = match self.node {
-            NodeEnum::Constraint(ref constraint)
-                if constraint.contype() == ConstrType::ConstrDefault =>
-            {
-                let expr = constraint.raw_expr.as_deref().unwrap();
-                if let Some(s) = node_to_string(expr) {
-                    return Ok(format!("DEFAULT {}", s));
-                }
-                "".to_owned()
-            }
-            NodeEnum::Constraint(ref constraint)
-                if constraint.contype() == ConstrType::ConstrCheck =>
-            {
-                let expr = constraint.raw_expr.as_deref().unwrap();
-                if let Some(s) = node_to_string(expr) {
-                    return Ok(format!("CONSTRAINT {} CHECK ({})", self.name, s));
-                }
-                "".to_owned()
-            }
-            _ => "".to_owned(),
-        };
-        Ok(s)
-    }
-}
+impl ConstraintInfo {}
 
 impl DeltaItem for ConstraintInfo {
     type SqlNode = Table;
@@ -41,8 +16,20 @@ impl DeltaItem for ConstraintInfo {
     }
 
     fn create(self, item: &Self::SqlNode) -> anyhow::Result<Vec<String>> {
-        let sql = format!("ALTER TABLE ONLY {} ADD {}", item.id, self.generate_sql()?);
+        let sql = format!("ALTER TABLE ONLY {} ADD {}", item.id, self);
         Ok(vec![sql])
+    }
+
+    fn rename(self, item: &Self::SqlNode, new: Self) -> anyhow::Result<Vec<String>> {
+        let sql1 = self.to_string().replace(&self.name, &new.name);
+        let sql2 = new.to_string();
+        if sql1 == sql2 {
+            return Ok(vec![format!(
+                "ALTER TABLE ONLY {} RENAME CONSTRAINT {} TO {}",
+                item.id, self.name, new.name
+            )]);
+        }
+        Ok(vec![])
     }
 
     fn alter(self, item: &Self::SqlNode, new: Self) -> anyhow::Result<Vec<String>> {
@@ -55,9 +42,39 @@ impl DeltaItem for ConstraintInfo {
     }
 }
 
+impl fmt::Display for ConstraintInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self.node {
+            NodeEnum::Constraint(ref constraint)
+                if constraint.contype() == ConstrType::ConstrDefault =>
+            {
+                let expr = constraint.raw_expr.as_deref().unwrap();
+                format!("DEFAULT {}", node_to_string(expr).unwrap())
+            }
+            NodeEnum::Constraint(ref constraint)
+                if constraint.contype() == ConstrType::ConstrCheck =>
+            {
+                let expr = constraint.raw_expr.as_deref().unwrap();
+                format!(
+                    "CONSTRAINT {} CHECK ({})",
+                    self.name,
+                    node_to_string(expr).unwrap()
+                )
+            }
+            // TODO: support other constraints (primary key / unique will be normalized to a separate SQL).
+            NodeEnum::Constraint(ref _constraint) => "".to_owned(),
+            ref v => unreachable!(
+                "ConstraintInfo::generate_sql: node should only be constraint, got {:?}",
+                v
+            ),
+        };
+        write!(f, "{}", s)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::parser::Table;
+    use crate::{parser::Table, Differ, MigrationPlanner};
     use anyhow::Result;
 
     #[test]
@@ -72,7 +89,7 @@ mod tests {
             .default
             .as_ref()
             .unwrap();
-        let sql = constraint.generate_sql()?;
+        let sql = constraint.to_string();
         assert_eq!(sql, "DEFAULT random_name(1)");
         Ok(())
     }
@@ -89,8 +106,23 @@ mod tests {
             .default
             .as_ref()
             .unwrap();
-        let sql = constraint.generate_sql()?;
+        let sql = constraint.to_string();
         assert_eq!(sql, "DEFAULT 'abcd'");
         Ok(())
+    }
+
+    #[test]
+    fn table_rename_constraint_should_work() {
+        let s1 = "CREATE TABLE foo (name text, constraint c1 CHECK (length(name) > 5))";
+        let s2 = "CREATE TABLE foo (name text, constraint c2 CHECK (length(name) > 5))";
+        let old: Table = s1.parse().unwrap();
+        let new: Table = s2.parse().unwrap();
+        let diff = old.diff(&new).unwrap().unwrap();
+        let plan = diff.plan().unwrap();
+        assert_eq!(plan.len(), 1);
+        assert_eq!(
+            plan[0],
+            "ALTER TABLE ONLY public.foo RENAME CONSTRAINT c1 TO c2"
+        );
     }
 }

--- a/src/types/differ.rs
+++ b/src/types/differ.rs
@@ -18,7 +18,7 @@ where
 
         let self_str = self.to_string();
         let new_str = new.to_string();
-        if self != new && self_str != new_str {
+        if self_str != new_str {
             let diff = create_diff(self, new)?;
             Ok(Some(NodeDiff {
                 old: Some(self.clone()),


### PR DESCRIPTION
Previously rename is not addressed. Due to the natural of the diffing, it will be treated as drop/create for the column/constraints if the only change is just name.

A new logic is added for specific case: if only one column/constraint is removed and one new column/constraint is added, we will check if this is a rename case.

```rust
// check if it is a case for rename
if self.added.len() == 1 && self.removed.len() == 1 {
    let added = self.added.iter().next().unwrap();
    let removed = self.removed.iter().next().unwrap();
    let result = removed.to_owned().rename(item, added.to_owned())?;
    if !result.is_empty() {
        migrations.extend(result);
        is_rename = true;
    }
}
```